### PR TITLE
Fixed a link to "A Farewell to Alms"

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@
 * [23 Things They Don't Tell You About Capitalism](http://www.goodreads.com/book/show/8913542-23-things-they-don-t-tell-you-about-capitalism) by Ha-Joon Chang
 * [The Ascent of Money: A Financial History of the World](https://www.goodreads.com/book/show/2714607-the-ascent-of-money) by Niall Ferguson
 * [Debt - Updated and Expanded: The First 5,000 Years](https://www.goodreads.com/book/show/6617037-debt) by David Graeber
-* [A Farewell to Alms : A Brief Economic History of the World](http://www.goodreads.com/book/show/150437.A_Farewell_to_Alms) by Gregory Clark
+* [A Farewell to Alms : A Brief Economic History of the World](https://www.goodreads.com/book/show/150437.A_Farewell_to_Alms) by Gregory Clark
 * [The Bottom Billion: Why the Poorest Countries are Failing and What Can Be Done About It](https://www.goodreads.com/book/show/493371.The_Bottom_Billion) by Paul Collier
 * [Currency Wars: The Making of the Next Global Crisis](https://www.goodreads.com/book/show/11515298-currency-wars) by James Rickards
 * [Economic Facts and Fallacies](https://www.goodreads.com/book/show/2064279.Economic_Facts_and_Fallacies) by Thomas Sowell

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@
 * [23 Things They Don't Tell You About Capitalism](http://www.goodreads.com/book/show/8913542-23-things-they-don-t-tell-you-about-capitalism) by Ha-Joon Chang
 * [The Ascent of Money: A Financial History of the World](https://www.goodreads.com/book/show/2714607-the-ascent-of-money) by Niall Ferguson
 * [Debt - Updated and Expanded: The First 5,000 Years](https://www.goodreads.com/book/show/6617037-debt) by David Graeber
-* [A Farewell to Alms : A Brief Economic History of the World: A Brief Economic History of the World](https://www.goodreads.com/book/show/10799.A_Farewell_to_Arms) by Gregory Clark
+* [A Farewell to Alms : A Brief Economic History of the World](http://www.goodreads.com/book/show/150437.A_Farewell_to_Alms) by Gregory Clark
 * [The Bottom Billion: Why the Poorest Countries are Failing and What Can Be Done About It](https://www.goodreads.com/book/show/493371.The_Bottom_Billion) by Paul Collier
 * [Currency Wars: The Making of the Next Global Crisis](https://www.goodreads.com/book/show/11515298-currency-wars) by James Rickards
 * [Economic Facts and Fallacies](https://www.goodreads.com/book/show/2064279.Economic_Facts_and_Fallacies) by Thomas Sowell


### PR DESCRIPTION
The previous link was to "A Farewell to **Arms**" by Ernest Hemingway. Replaced it with a link to "A Farewell to **Alms**" by Gregory Clark, which is actually about economics.

Previous link: https://www.goodreads.com/book/show/10799.A_Farewell_to_Arms

New link: https://www.goodreads.com/book/show/150437.A_Farewell_to_Alms

Fixed the link title too.