### PR TITLE
Fix Brene Brown link and add Meditations by Marcus Aurelius

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@
 | Rapt: Attention and the Focused Life: Winifred Gallagher | Winifred Gallagher | [3.54](https://www.goodreads.com/book/show/6262510-rapt) |  |  
 | The Fine Art of Small Talk: How To Start a Conversation, Keep It Going, Build Networking Skills -- and Leave a Positive Impression | Debra Fine | [3.36](https://www.goodreads.com/book/show/93409.The_Fine_Art_of_Small_Talk) | 2005 |  
 | Snoop: What Your Stuff Says About You: Sam Gosling | Sam Gosling | [3.33](https://www.goodreads.com/book/show/1581330.Snoop) |  |  
-| Gifs of Immperfection | Brene Brown | [](https://www.goodreads.com/book/show/7015403-the-gifts-of-imperfection) |  |  
+| Gifts of Imperfection | Brene Brown | [4.18](https://www.goodreads.com/book/show/7015403-the-gifts-of-imperfection) |  |  
+| Meditations | Marcus Aurelius | [4.21](https://www.goodreads.com/book/show/30659.Meditations) |  |
 
 ## Autobiographies and Biographies
 | Name | Author | Goodreads Rating | Year Published |  


### PR DESCRIPTION
## In this pull request
- [x]  I am adding a new book.
- [ ]  I am adding a new category
- [ ] Removing a book
- [x] Fixing a link

## Adding new book
* The book I am adding is *Meditations* by Marcus Aurelius
* I am adding this book to the Philosophy section.
* I have read this book 1 times.
* I think this book deserves to be in this list because it is an excellent introduction to Stoic philosophy and teaches practical wisdom that is applicable to virtually everyone. A few contemporary principles of psychology [like the inner locus of control](https://en.wikipedia.org/wiki/Locus_of_control) are based upon the Stoics. The concept that [one should focus solely on what is in their control](http://existentialcomics.com/comic/48) comes from the Stoics.

## Fixing a link

* The book I fixed was *Gifts of Imperfection* by Brene Brown
* This book is in the Philosophy and Psychology section
* I haven't read this book
* I noticed that the title was misspelled and that it didn't have a Goodreads link, so I went ahead and added that as well. Her other book
