### PR TITLE
Adding "How Buildings Learn"

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,8 @@
 | Pattern Language: Towns, Buildings, Construction | Christopher Alexander, Sara Ishikawa, Murray Silverstein, Max Jacobson, Ingrid Fiksdahl-King and Shlomo Angel | [4.38](https://www.goodreads.com/book/show/79766.A_Pattern_Language) | 1977 |  
 | Don't Make Me Think, Revisited: A Common Sense Approach to Web Usability | Steve Krug | [4.24](https://www.goodreads.com/book/show/18197267-don-t-make-me-think-revisited) | 2014 |  
 | The Design of Everyday Things | Donald Norman | [4.18](http://www.goodreads.com/book/show/840.The_Design_of_Everyday_Things) | 2002 |  
-| The Art of Looking Sideways | Alan Fletcher | [4.10](https://www.goodreads.com/book/show/15778.The_Art_of_Looking_Sideways) | 2001 |  
+| The Art of Looking Sideways | Alan Fletcher | [4.10](https://www.goodreads.com/book/show/15778.The_Art_of_Looking_Sideways) | 2001 |
+| How Buildings Learn: What Happens After They're Built | Stewart Brand | [4.32](https://www.goodreads.com/book/show/38310.How_Buildings_Learn) | 1995 |
 
 ## Travel
 | Name | Author | Goodreads Rating | Year Published |  


### PR DESCRIPTION
## In this pull request
- [x]  I am adding a new book.
- [ ]  I am adding a new category
- [ ] Removing a book

## Adding new book
* The book I am adding is "How Buildings Learn: What happens After They're Built"
* I am adding this book to Design section.
* I have read this book 1 times.
* I think this book deserves to be in this list because in *How Buildings Learn*, Brand makes a compelling case for us to think of design and building as a sequence, an evolutionary process rather than a singular, lump-sum event. It is an excellent study of systems told through the very tractable idea of a residential house.

For added context...

Steve Jobs (among others), [cites](https://www.theguardian.com/books/2013/may/05/stewart-brand-whole-earth-catalog) Stewart Brand as a major influence. Be it in his role as the instigator that propelled NASA to release the first picture of the whole Earth or in his role as the founder of the [Whole Earth Catalog](https://en.wikipedia.org/wiki/Whole_Earth_Catalog), [The Well](https://en.wikipedia.org/wiki/WELL_(virtual_community)) (one of the internet's first virtual communities) and [The Long Now Foundation](https://en.wikipedia.org/wiki/Long_Now_Foundation) among other [ventures](https://en.wikipedia.org/wiki/Stewart_Brand#Works).
