### PR TITLE
Added an Oliver Sacks favourite

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ If you like Mind Expanding books you should check out my new project http://diff
 | The Extended Phenotype: The Long Reach of the Gene | Richard Dawkins | [4.07](https://www.goodreads.com/book/show/61538.The_Extended_Phenotype) | 1999 |  
 | Rare Earth: Why Complex Life is Uncommon in the Universe | Peter D. Ward, Donald Brownlee | [4.06](https://www.goodreads.com/book/show/88552.Rare_Earth) | 2003 |  
 | Stiff: The Curious Lives of Human Cadavers | Mary Roach | [4.05](https://www.goodreads.com/book/show/32145.Stiff) | 2004 |  
+| The Man Who Mistook His Wife for A Hat and Other Clinical Tales | Oliver Sacks | [4.05](https://www.goodreads.com/book/show/63697.The_Man_Who_Mistook_His_Wife_for_a_Hat_and_Other_Clinical_Tales) | 1998 |  
 | Darwin's Dangerous Idea | Daniel C. Dennett | [4.03](https://www.goodreads.com/book/show/2068.Darwin_s_Dangerous_Idea) |  |  
 | The Inevitable: Understanding the 12 Technological Forces That Will Shape Our Future | Kevin Kelly | [4.02](https://www.goodreads.com/book/show/27209431-the-inevitable) | 2016 |  
 | The Outer Limits of Reason: What Science, Mathematics, and Logic Cannot Tell Us | Noson S. Yanofsky | [4.00](http://www.goodreads.com/book/show/17841838-the-outer-limits-of-reason) | 2013 |  


### PR DESCRIPTION
## In this pull request
- [x]  I am adding a new book.
- [ ]  I am adding a new category
- [ ] Removing a book

## Adding new book
* The book I am adding is  The Man Who Mistook His Wife for A Hat and OtherClinical Tales
* I am adding this book to the Science and Medicine section.
* I have read this book 1 time.
* I think this book deserves to be in this list because this book sits right at the intersection of interesting medical trivia/cases and real stories involving real people from that time. Sacks' inimitable style makes this one a personal favourite showing just how a compassionate, curious physician, invested in his patients' care can present a unique worldview on these cases, both neurological and psychiatric.     
This is one of the rare books in an already unique medical non-fiction category that manages to achieve this.
