### PR TITLE
Links to cross-origin destinations are unsafe

### DIFF
--- a/app/src/components/amazonurl.js
+++ b/app/src/components/amazonurl.js
@@ -7,7 +7,7 @@ const getTargetURL = (book) => {
 
 export default ({ book }) => {
     return (
-        <OutboundLink href={getTargetURL(book)} target="_blank">
+        <OutboundLink href={getTargetURL(book)} target="_blank" rel="noreferrer">
             <img alt="Amazon link" style={{ marginBottom: "-8px" }} src="https://img.icons8.com/color/48/000000/amazon.png"/>
         </OutboundLink>
     )

--- a/app/src/components/bookcard.js
+++ b/app/src/components/bookcard.js
@@ -1,102 +1,95 @@
-import PropTypes from "prop-types"
-import React, { useState } from "react"
-import StarRatings from "react-star-ratings"
-import { Card, Row, Col } from "react-bootstrap"
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import StarRatings from 'react-star-ratings';
+import { Card, Row, Col } from 'react-bootstrap';
 
-import AmazonURL from "../components/amazonurl"
-import Bookmark from "../components/bookmark"
-import GoodReadsImage from "../components/goodreadsimage"
+import AmazonURL from '../components/amazonurl';
+import Bookmark from '../components/bookmark';
+import GoodReadsImage from '../components/goodreadsimage';
 
-const truncateContent = content => {
-  if (!content) {
-    return ""
-  }
-  return content.length > 350 ? content.substring(0, 350) + "..." : content
-}
+const truncateContent = (content) => {
+	if (!content) {
+		return '';
+	}
+	return content.length > 350 ? content.substring(0, 350) + '...' : content;
+};
 
-const showFullText = content => {
-  if (!content) {
-    return ""
-  }
-  return content
-}
+const showFullText = (content) => {
+	if (!content) {
+		return '';
+	}
+	return content;
+};
 
 const BookCard = ({ book }) => {
-  const [show, toggleShow] = useState(false)
-  return (
-    <Card style={{ marginBottom: "15px" }}>
-      <Row>
-        <Col xs={12} md={4} xl={2}>
-          <Card.Img
-            style={{
-              paddingLeft: "15px",
-              paddingRight: "15px",
-              paddingTop: "30px",
-            }}
-            src={book.image_url}
-          />
-        </Col>
-        <Col xs={12} md={8} xl={10}>
-          <Card.Body>
-            <Card.Title>{book.title}</Card.Title>
-            <Card.Subtitle className="text-muted">
-              <Card.Text style={{ paddingTop: "2px"}}>
-                {book.author} <b>{book.year ? book.year : null}</b>
-              </Card.Text>
-              <StarRatings
-                rating={parseFloat(book.rating)}
-                numberOfStars={5}
-                starDimension="18px"
-                starSpacing="1px"
-                starRatedColor="#fa604a"
-              />
-              <div style={{display: "flex",alignItems: "center",paddingTop: ".75rem",}} >
-                <div style={{ width: "30px", height: "30px", marginRight: "5px" }}>
-                  {book.amazon_url ? <AmazonURL book={book} /> : null}
-                </div>
-                <div style={{ width: "30px", height: "30px" }}>
-                  <a href={book.url}>
-                    <GoodReadsImage />
-                  </a>
-                </div>
-                <Bookmark book={book} />
-              </div>
-            </Card.Subtitle>
-            <p
-              style={{ color: "gray", fontSize: "0.8rem", paddingTop: "1rem" }}
-            >
-              {!show && truncateContent(book.description)}
-              {show && showFullText(book.description)}
-            </p>
-            {!show && (
-              <button
-                className="btn btn-sm btn-primary "
-                onClick={() => toggleShow(true)}
-              >
-                Show More
-              </button>
-            )}
-            {show && (
-              <button
-                className="btn btn-sm btn-primary "
-                onClick={() => toggleShow(false)}
-              >
-                Show Less
-              </button>
-            )}
-          </Card.Body>
-        </Col>
-      </Row>
-    </Card>
-  )
-}
+	const [ show, toggleShow ] = useState(false);
+	return (
+		<Card style={{ marginBottom: '15px' }}>
+			<Row>
+				<Col xs={12} md={4} xl={2}>
+					<Card.Img
+						style={{
+							paddingLeft: '15px',
+							paddingRight: '15px',
+							paddingTop: '30px'
+						}}
+						src={book.image_url}
+						alt={book.title}
+					/>
+				</Col>
+				<Col xs={12} md={8} xl={10}>
+					<Card.Body>
+						<Card.Title>{book.title}</Card.Title>
+						<Card.Subtitle className="text-muted">
+							<Card.Text style={{ paddingTop: '2px' }}>
+								{book.author} <b>{book.year ? book.year : null}</b>
+							</Card.Text>
+							<StarRatings
+								rating={parseFloat(book.rating)}
+								numberOfStars={5}
+								starDimension="18px"
+								starSpacing="1px"
+								starRatedColor="#fa604a"
+							/>
+							<div style={{ display: 'flex', alignItems: 'center', paddingTop: '.75rem' }}>
+								<div style={{ width: '30px', height: '30px', marginRight: '5px' }}>
+									{book.amazon_url ? <AmazonURL book={book} /> : null}
+								</div>
+								<div style={{ width: '30px', height: '30px' }}>
+									<a href={book.url}>
+										<GoodReadsImage />
+									</a>
+								</div>
+								<Bookmark book={book} />
+							</div>
+						</Card.Subtitle>
+						<p style={{ color: 'gray', fontSize: '0.8rem', paddingTop: '1rem' }}>
+							{!show && truncateContent(book.description)}
+							{show && showFullText(book.description)}
+						</p>
+						{!show && (
+							<button className="btn btn-sm btn-primary " onClick={() => toggleShow(true)}>
+								Show More
+							</button>
+						)}
+						{show && (
+							<button className="btn btn-sm btn-primary " onClick={() => toggleShow(false)}>
+								Show Less
+							</button>
+						)}
+					</Card.Body>
+				</Col>
+			</Row>
+		</Card>
+	);
+};
 
 BookCard.propTypes = {
-  siteTitle: PropTypes.object,
-}
+	siteTitle: PropTypes.object
+};
 
 BookCard.defaultProps = {
-  book: {},
-}
+	book: {}
+};
 
-export default BookCard
+export default BookCard;

--- a/app/src/styles/sidebar.css
+++ b/app/src/styles/sidebar.css
@@ -10,7 +10,7 @@
 }
 
 .nav-link {
-  font-size: .900rem;
+  font-size: 0.9rem;
 }
 
 #sidebar-wrapper {
@@ -33,6 +33,6 @@
 .navbar {
   padding: 10px 0px;
 }
-
-
-
+.navbar-toggler {
+  margin-bottom: 1.2rem;
+}


### PR DESCRIPTION
Improve performance and prevent security vulnerabilities

When you link to a page on another site using the target="_blank" attribute, you can expose your site to performance and security issues:

The other page may run on the same process as your page. If the other page is running a lot of JavaScript, your page's performance may suffer.

The other page can access your window object with the window.opener property. This may allow the other page to redirect your page to a malicious URL.

Adding rel="noopener" or rel="noreferrer" to your target="_blank" links avoids these issues.

