### PR TITLE
Added 'Freakonomics' book to the Economics section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ If you like Mind Expanding books you should check out my new project http://diff
 | Economic Facts and Fallacies | Thomas Sowell | [4.18](https://www.goodreads.com/book/show/2064279.Economic_Facts_and_Fallacies) | 2008 |  
 | Debt - Updated and Expanded: The First 5,000 Years | David Graeber | [4.17](https://www.goodreads.com/book/show/6617037-debt) | 2011 |  
 | Capital in the Twenty-First Century | Thomas Piketty | [4.01](http://www.goodreads.com/book/show/18736925-capital-in-the-twenty-first-century) | 2014 |  
+| Freakonomics: A Rogue Economist Explores the Hidden Side of Everything |  Steven D. Levitt, Stephen J. Dubner | [3.98](https://www.goodreads.com/book/show/1202.Freakonomics) | 2006 |
 | 23 Things They Don't Tell You About Capitalism | Ha-Joon Chang | [3.97](http://www.goodreads.com/book/show/8913542-23-things-they-don-t-tell-you-about-capitalism) | 2010 |  
 | The Signal and the Noise: Why So Many Predictions Fail--but Some Don't | Nate Silver | [3.96](https://www.goodreads.com/book/show/13588394-the-signal-and-the-noise) | 2012 |  
 | Currency Wars: The Making of the Next Global Crisis | James Rickards | [3.96](https://www.goodreads.com/book/show/11515298-currency-wars) | 2011 |  

--- a/README.md
+++ b/README.md
@@ -470,10 +470,10 @@ If you like Mind Expanding books you should check out my new project http://diff
 | The Kite Runner | Khaled Hosseini | [4.3](https://www.goodreads.com/book/show/77203.The_Kite_Runner) | 2003 |  
 | The Pillars of the Earth | Ken Follett | [4.29](https://www.goodreads.com/book/show/5043.The_Pillars_of_the_Earth?from_search=true) | 1989 |  
 | Kane and Abel | Jeffrey Archer | [4.27](http://www.goodreads.com/book/show/78983.Kane_and_Abel) | 1979 |  
+| Memoirs of a Geisha | Arthur Golden | [4.12](https://www.goodreads.com/book/show/929.Memoirs_of_a_Geisha) | 1997 |
 | One Day in the Life of Ivan Denisovich | Aleksandr Solzhenitsyn | [4](https://www.goodreads.com/book/show/17125.One_Day_in_the_Life_of_Ivan_Denisovich) | 1962 |
 | Emma | Jane Austen | [3.99](https://www.goodreads.com/book/show/6969.Emma) | 1815 |  
 | Sophie's World: A Novel About the History of Philosophy | Jostein Gaarder and Paulette Moller | [3.88](https://www.goodreads.com/book/show/10959.Sophie_s_World) | 1991 |  
-| Memoirs of a Geisha | Arthur Golden | [4.12](https://www.goodreads.com/book/show/929.Memoirs_of_a_Geisha) | 1997 |
 
 ### Humor
 | Name | Author | Goodreads Rating | Year Published |  

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ If you like Mind Expanding books you should check out my new project http://diff
 | One Day in the Life of Ivan Denisovich | Aleksandr Solzhenitsyn | [4](https://www.goodreads.com/book/show/17125.One_Day_in_the_Life_of_Ivan_Denisovich) | 1962 |
 | Emma | Jane Austen | [3.99](https://www.goodreads.com/book/show/6969.Emma) | 1815 |  
 | Sophie's World: A Novel About the History of Philosophy | Jostein Gaarder and Paulette Moller | [3.88](https://www.goodreads.com/book/show/10959.Sophie_s_World) | 1991 |  
+| Memoirs of a Geisha | Arthur Golden | [4.12](https://www.goodreads.com/book/show/929.Memoirs_of_a_Geisha) | 1997 |
 
 ### Humor
 | Name | Author | Goodreads Rating | Year Published |  


### PR DESCRIPTION
#In this pull request
- [x]  I am adding a new book.


## Adding new book
* The book I am adding is Freakonomics.
* I am adding this book to Economics section.
* I have read this book  one time.
* I think this book deserves to be in this list because Freakonomics establishes this unconventional premise: If morality represents how we would like the world to work, then economics represents how it actually does work. You don’t need be Math wizard or econometric genius to understand the economics , one should dive deep into the questions in day to day life and solve it by simple approach of common sense. This is what it teaches in Freakonomics and thus making it exciting and intriguing and you might keep thinking that most of the complex problems have the simplest solutions only when ,one would be able to connect the dots.

