### PR TITLE
Updated bookcard.js

### DIFF
--- a/app/src/components/bookcard.js
+++ b/app/src/components/bookcard.js
@@ -67,7 +67,7 @@ const BookCard = ({ book }) => {
 							{!show && truncateContent(book.description)}
 							{show && showFullText(book.description)}
 						</p>
-						{!show && (
+						{!show && book.description.length>350 &&(
 							<button className="btn btn-sm btn-primary " onClick={() => toggleShow(true)}>
 								Show More
 							</button>


### PR DESCRIPTION
## In this pull request
I have removed the "show more" button for book descriptions that are less than 350 words.


## Updating book.card js

- I have edited the code because for descriptions less than one line, the button was futile.
- The page looks much cleaner now.
