### PR TITLE
fixes goodread button link not opening in new tab

### DIFF
--- a/app/src/components/bookcard.js
+++ b/app/src/components/bookcard.js
@@ -56,7 +56,7 @@ const BookCard = ({ book }) => {
 									{book.amazon_url ? <AmazonURL book={book} /> : null}
 								</div>
 								<div style={{ width: '30px', height: '30px' }}>
-									<a href={book.url}>
+									<a href={book.url} target="_blank">
 										<GoodReadsImage />
 									</a>
 								</div>


### PR DESCRIPTION
Fixing Bug #465 when you try to read book by clicking goodread button now the link open in new tab.

## In this pull request 
- [ ]  I am adding a new book.
- [ ]  I am adding a new category
- [ ] Removing a book


