### PR TITLE
Add "Programming and Technology" to categories.json #470

### DIFF
--- a/app/src/data/categories.json
+++ b/app/src/data/categories.json
@@ -20,6 +20,10 @@
     "emoji": "🔬"
   },
   {
+    "name": "Programming and Technology",
+    "emoji": "💻"
+  },
+  {
     "name": "Logic and Problem Solving",
     "emoji": "🧩"
   },


### PR DESCRIPTION
## In this pull request 
- [ ]  I am adding a new book.
- [x]  I am adding a new category
- [ ] Removing a book


## Add new category
* The category I am adding is **Programming and Technology**
* The reason why I think this category should be there is because: **resolve issue #470** 
* - [ ] I have added at least one book to this category 

