### PR TITLE
Remove credits and license from books category and give them their own heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,12 +698,12 @@ If you like Mind Expanding books you should check out my new project http://diff
 
 <a href="#top"><img src="https://img.shields.io/badge/Back%20to%20Top-↑-blue"/></a>
 
-## Credits
+# Credits
 * [@hackerkid](https://github.com/hackerkid) for starting the list.
 * [@geritol](https://github.com/geritol) for building the framework for maintaining the list.
 * All the [contributors](https://github.com/hackerkid/Mind-Expanding-Books/graphs/contributors) for keeping the list updated by adding new books.
 
-## License
+# License
 [![CC0](http://i.creativecommons.org/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Vishnu Ks](https://github.com/hackerkid) has waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
It implied that they are books about licenses and credits

I have not filled the todo below because it is irrelevant to my proposed change.
(todo:please remove this todo and the sections you did not check below before you make your pull request.
If you are unsure, please check other PRs like this one: https://github.com/hackerkid/Mind-Expanding-Books/pull/207#issue-377268434)

## In this pull request 
- [ ]  I am adding a new book.
- [ ]  I am adding a new category
- [ ] Removing a book

## Adding new book
* The book I am adding is _ _ _ _
* I am adding this book to _ _ _ _ section.
* I have read this book _ _ times.
* I think this book deserves to be in this list because _ _ _ _

**If you are adding more than 1 books duplicate this section**

## Add new category
* The category I am adding is _ _ _ _
* The reason why I think this category should be there is because _ _ _ _
* - [ ] I have added at least one book to this category 

**If you are adding more than 1 category duplicate this section**

## Remove a book
* The book I am removing is _ _ _ _
* I am removing this book from _ _ _ _ section.
* I have read this book _ _ times.
* I think this book should not be in this list because _ _ _ _

**If you are removing more than 1 book duplicate this section.**
