### PR TITLE
fix: 'show more' button only appear for long description

### DIFF
--- a/app/src/components/bookcard.js
+++ b/app/src/components/bookcard.js
@@ -67,15 +67,19 @@ const BookCard = ({ book }) => {
 							{!show && truncateContent(book.description)}
 							{show && showFullText(book.description)}
 						</p>
-						{!show && book.description.length>350 &&(
-							<button className="btn btn-sm btn-primary " onClick={() => toggleShow(true)}>
-								Show More
-							</button>
-						)}
-						{show && (
-							<button className="btn btn-sm btn-primary " onClick={() => toggleShow(false)}>
-								Show Less
-							</button>
+						{book.description.length>350 && (
+							<>
+							{!show  &&(
+								<button className="btn btn-sm btn-primary " onClick={() => toggleShow(true)}>
+									Show More
+								</button>
+							)}
+							{show && (
+								<button className="btn btn-sm btn-primary " onClick={() => toggleShow(false)}>
+									Show Less
+								</button>
+							)}
+							</>
 						)}
 					</Card.Body>
 				</Col>


### PR DESCRIPTION
### What does this PR do?

Write a condition that allows showing 'show more' button only if the book description is longer then 350 character.

Fixed #438 

### Type of change
- Backend bug fix (non-breaking change which fixes an issue)